### PR TITLE
Rename EasyGeoIP::Response to EasyGeoIP::GeoData

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ No database downloads, no registration, no API keys, ~~no~~ [minimal](https://gi
 ```ruby
 EasyGeoIP.query("8.8.8.8")
 
-=> #<EasyGeoIP::Response:0x007f91b9512960
+=> #<EasyGeoIP::GeoData:0x007f91b9512960
  @city="Mountain View",
  @continent_code="NA",
  @country="United States",
@@ -35,9 +35,10 @@ EasyGeoIP.query("2001:4860:4860::8888")
 See the 'Usage' section for more information.
 
 ## IP Geolocation Services
+
 EasyGeoIP currently supports the geolocation services listed below. All these services are free, open source, and require no registration or authentication.
 
-Regardless of which service is used, geolocation information is returned in the same format for ease of use. See the `EasyGeoIP::Response` section below for more information.
+Regardless of which service is used, geolocation information is returned in the same format for ease of use. See the `EasyGeoIP::GeoData` section below for more information.
 
 #### Telize (Default) `:telize`
 * **HTTPS**: Yes
@@ -113,13 +114,13 @@ end
 
 #### Querying IPs - One Method to Rule Them All
 
-Use the `query` method to retrieve geolocation information for a specified IPv4 or IPv6 address. An instance of `EasyGeoIP::Response` is returned.
+Use the `query` method to retrieve geolocation information for a specified IPv4 or IPv6 address. An instance of `EasyGeoIP::GeoData` is returned.
 
 ```ruby
 EasyGeoIP.query("8.8.8.8")
 
-# `EasyGeoIP::Response` object is returned
-=> #<EasyGeoIP::Response:0x007f91b9512960
+# `EasyGeoIP::GeoData` object is returned
+=> #<EasyGeoIP::GeoData:0x007f91b9512960
  @city="Mountain View",
  @continent_code="NA",
  @country="United States",
@@ -142,9 +143,9 @@ EasyGeoIP.query("")
 EasyGeoIP.query
 ```
 
-#### EasyGeoIP::Response
+#### EasyGeoIP::GeoData
 
-Regardless of which service you use, geolocation information is returned as a `EasyGeoIP::Response` object where its attributes are easily accessible. Calling `#to_hash` returns all information as a `Hash`.
+Regardless of which service you use, geolocation information is returned as a `EasyGeoIP::GeoData` object where its attributes are easily accessible. Calling `#to_hash` returns all information as a `Hash`.
 
 ```ruby
 geo_data = EasyGeoIP.query("8.8.8.8")

--- a/lib/easy_geoip/api/freegeoip.rb
+++ b/lib/easy_geoip/api/freegeoip.rb
@@ -11,7 +11,7 @@ module EasyGeoIP
         "https://freegeoip.net/json/#{ip}"
       end
 
-      def self.standardize_response(json)
+      def self.standardize_geodata(json)
         {
           ip:            json["ip"],
           country:       json["country_name"],

--- a/lib/easy_geoip/api/nekudo.rb
+++ b/lib/easy_geoip/api/nekudo.rb
@@ -11,7 +11,7 @@ module EasyGeoIP
         "http://geoip.nekudo.com/api/#{ip}"
       end
 
-      def self.standardize_response(json)
+      def self.standardize_geodata(json)
         {
           ip:            json["ip"],
           country:       json["country"]["name"],

--- a/lib/easy_geoip/api/query.rb
+++ b/lib/easy_geoip/api/query.rb
@@ -1,15 +1,15 @@
 require "easy_geoip/client"
-require "easy_geoip/response"
+require "easy_geoip/geo_data"
 
 module EasyGeoIP
   module API
     module Query
       def query(ip = "")
-        url          = url(ip)
-        response     = EasyGeoIP::Client.get_json(url)
-        standardized = standardize_response(response)
+        url      = url(ip)
+        json     = EasyGeoIP::Client.get_json(url)
+        geo_data = standardize_geodata(json)
 
-        EasyGeoIP::Response.new(standardized)
+        EasyGeoIP::GeoData.new(geo_data)
       end
     end
   end

--- a/lib/easy_geoip/api/telize.rb
+++ b/lib/easy_geoip/api/telize.rb
@@ -11,7 +11,7 @@ module EasyGeoIP
         "https://www.telize.com/geoip/#{ip}"
       end
 
-      def self.standardize_response(json)
+      def self.standardize_geodata(json)
         {
           ip:             json["ip"],
           country:        json["country"],

--- a/lib/easy_geoip/geo_data.rb
+++ b/lib/easy_geoip/geo_data.rb
@@ -1,5 +1,5 @@
 module EasyGeoIP
-  class Response
+  class GeoData
     attr_reader :ip, :country, :country_code, :city, :region, :region_code,
                 :postal_code, :continent_code, :latitude, :longitude,
                 :time_zone, :isp

--- a/spec/lib/api/freegeoip_spec.rb
+++ b/spec/lib/api/freegeoip_spec.rb
@@ -18,10 +18,10 @@ describe EasyGeoIP::API::Freegeoip do
     }
   end
 
-  it ".query returns a correct EasyGeoIP::Response" do
+  it ".query returns a correct EasyGeoIP::GeoData" do
     VCR.use_cassette("freegeoip") do
       response = EasyGeoIP::API::Freegeoip.query("8.8.8.8")
-      response.must_be_instance_of(EasyGeoIP::Response)
+      response.must_be_instance_of(EasyGeoIP::GeoData)
 
       expected_response.each do |attribute, value|
         response.send(attribute).must_equal value
@@ -32,7 +32,7 @@ describe EasyGeoIP::API::Freegeoip do
   it ".query can make a real request" do
     live_request do
       response = EasyGeoIP::API::Freegeoip.query("8.8.8.8")
-      response.must_be_instance_of(EasyGeoIP::Response)
+      response.must_be_instance_of(EasyGeoIP::GeoData)
       response.ip.must_equal "8.8.8.8"
     end
   end

--- a/spec/lib/api/nekudo_spec.rb
+++ b/spec/lib/api/nekudo_spec.rb
@@ -18,10 +18,10 @@ describe EasyGeoIP::API::Nekudo do
     }
   end
 
-  it ".query returns a correct EasyGeoIP::Response" do
+  it ".query returns a correct EasyGeoIP::GeoData" do
     VCR.use_cassette("nekudo") do
       response = EasyGeoIP::API::Nekudo.query("8.8.8.8")
-      response.must_be_instance_of(EasyGeoIP::Response)
+      response.must_be_instance_of(EasyGeoIP::GeoData)
 
       expected_response.each do |attribute, value|
         response.send(attribute).must_equal value
@@ -32,7 +32,7 @@ describe EasyGeoIP::API::Nekudo do
   it ".query can make a real request" do
     live_request do
       response = EasyGeoIP::API::Nekudo.query("8.8.8.8")
-      response.must_be_instance_of(EasyGeoIP::Response)
+      response.must_be_instance_of(EasyGeoIP::GeoData)
       response.ip.must_equal "8.8.8.8"
     end
   end

--- a/spec/lib/api/telize_spec.rb
+++ b/spec/lib/api/telize_spec.rb
@@ -18,10 +18,10 @@ describe EasyGeoIP::API::Telize do
     }
   end
 
-  it ".query returns a correct EasyGeoIP::Response" do
+  it ".query returns a correct EasyGeoIP::GeoData" do
     VCR.use_cassette("telize") do
       response = EasyGeoIP::API::Telize.query("8.8.8.8")
-      response.must_be_instance_of(EasyGeoIP::Response)
+      response.must_be_instance_of(EasyGeoIP::GeoData)
 
       expected_response.each do |attribute, value|
         response.send(attribute).must_equal value
@@ -32,7 +32,7 @@ describe EasyGeoIP::API::Telize do
   it ".query can make a real request" do
     live_request do
       response = EasyGeoIP::API::Telize.query("8.8.8.8")
-      response.must_be_instance_of(EasyGeoIP::Response)
+      response.must_be_instance_of(EasyGeoIP::GeoData)
       response.ip.must_equal "8.8.8.8"
     end
   end

--- a/spec/lib/geo_data_spec.rb
+++ b/spec/lib/geo_data_spec.rb
@@ -1,7 +1,7 @@
 require "minitest_helper"
 
-describe EasyGeoIP::Response do
-  let(:response) { EasyGeoIP::Response.new(attributes) }
+describe EasyGeoIP::GeoData do
+  let(:response) { EasyGeoIP::GeoData.new(attributes) }
 
   let(:attributes) do
     {
@@ -22,20 +22,20 @@ describe EasyGeoIP::Response do
 
   describe ".new" do
     it "can be initialized without a parameter" do
-      EasyGeoIP::Response.new.must_be_instance_of EasyGeoIP::Response
+      EasyGeoIP::GeoData.new.must_be_instance_of EasyGeoIP::GeoData
     end
 
     it "can be initialized with attributes" do
-      response.must_be_instance_of EasyGeoIP::Response
+      response.must_be_instance_of EasyGeoIP::GeoData
     end
 
     it "can be initialized with incomplete attributes" do
-      EasyGeoIP::Response.new(ip: "8.8.8.8").
-        must_be_instance_of EasyGeoIP::Response
+      EasyGeoIP::GeoData.new(ip: "8.8.8.8").
+        must_be_instance_of EasyGeoIP::GeoData
     end
 
     it "ignores invalid attributes when initialized" do
-      EasyGeoIP::Response.new(foo: "bar").wont_respond_to :foo
+      EasyGeoIP::GeoData.new(foo: "bar").wont_respond_to :foo
     end
   end
 
@@ -47,11 +47,11 @@ describe EasyGeoIP::Response do
     end
 
     it "returns nil for missing attributes" do
-      EasyGeoIP::Response.new(ip: "8.8.8.8").city.must_be_nil
+      EasyGeoIP::GeoData.new(ip: "8.8.8.8").city.must_be_nil
     end
 
     it "stores partial attributes that are accessible" do
-      EasyGeoIP::Response.new(ip: "8.8.8.8").ip.must_equal "8.8.8.8"
+      EasyGeoIP::GeoData.new(ip: "8.8.8.8").ip.must_equal "8.8.8.8"
     end
   end
 
@@ -61,7 +61,7 @@ describe EasyGeoIP::Response do
   end
 
   it "#to_hash values are nil for missing attributes" do
-    hash = EasyGeoIP::Response.new(ip: "8.8.8.8").to_hash
+    hash = EasyGeoIP::GeoData.new(ip: "8.8.8.8").to_hash
 
     attributes.each do |attribute, _value|
       next if attribute == :ip
@@ -72,7 +72,7 @@ describe EasyGeoIP::Response do
   end
 
   it "#to_hash excludes invalid attributes from .new" do
-    hash = EasyGeoIP::Response.new(foo: "bar").to_hash
+    hash = EasyGeoIP::GeoData.new(foo: "bar").to_hash
 
     hash.keys.wont_include :foo
 


### PR DESCRIPTION
`GeoData`, is probably a better name for the geolocation information the API service returns.
